### PR TITLE
fix(path): Hide edit and delete buttons

### DIFF
--- a/src/frontend/components/LoginForm.tsx
+++ b/src/frontend/components/LoginForm.tsx
@@ -15,17 +15,17 @@ export const LoginForm: FC<LoginFormProps> = ({ submit }) => {
   });
 
   const handleSubmission = useCallback(() => {
-    const failed = false;
+    let failed = false;
     if (!form.username) {
       failed = true;
       toast.error('Please provide your username.');
     }
-    
+
     if (!form.password) {
       failed = true;
       toast.error('Please provide your password.');
     }
-    
+
     if (failed) {
       return;
     }

--- a/src/frontend/components/Navbar.tsx
+++ b/src/frontend/components/Navbar.tsx
@@ -8,7 +8,8 @@ import {
   Nav,
   NavItem,
   NavLink,
-  Button, NavbarText,
+  Button,
+  NavbarText,
 } from 'reactstrap';
 import { UserContext } from '../services/providers';
 import { captureError } from '../utils';
@@ -70,17 +71,17 @@ export const AppNavbar: FC = () => {
             </>
           ) : (
             <>
-            <NavbarText className={"me-3"}>Welcome, {user.name}</NavbarText>
-            <NavItem>
-              <Button
-                color="secondary"
-                onClick={() => {
-                  handleLogout();
-                }}
-              >
-                Logout
-              </Button>
-            </NavItem>
+              <NavbarText className={'me-3'}>Welcome, {user.name}</NavbarText>
+              <NavItem>
+                <Button
+                  color="secondary"
+                  onClick={() => {
+                    handleLogout();
+                  }}
+                >
+                  Logout
+                </Button>
+              </NavItem>
             </>
           )}
         </Nav>

--- a/src/frontend/components/Navbar.tsx
+++ b/src/frontend/components/Navbar.tsx
@@ -8,7 +8,7 @@ import {
   Nav,
   NavItem,
   NavLink,
-  Button,
+  Button, NavbarText,
 } from 'reactstrap';
 import { UserContext } from '../services/providers';
 import { captureError } from '../utils';
@@ -69,6 +69,8 @@ export const AppNavbar: FC = () => {
               </NavItem>
             </>
           ) : (
+            <>
+            <NavbarText className={"me-3"}>Welcome, {user?.name}</NavbarText>
             <NavItem>
               <Button
                 color="secondary"
@@ -79,6 +81,7 @@ export const AppNavbar: FC = () => {
                 Logout
               </Button>
             </NavItem>
+            </>
           )}
         </Nav>
       </Collapse>

--- a/src/frontend/components/Navbar.tsx
+++ b/src/frontend/components/Navbar.tsx
@@ -70,7 +70,7 @@ export const AppNavbar: FC = () => {
             </>
           ) : (
             <>
-            <NavbarText className={"me-3"}>Welcome, {user?.name}</NavbarText>
+            <NavbarText className={"me-3"}>Welcome, {user.name}</NavbarText>
             <NavItem>
               <Button
                 color="secondary"

--- a/src/frontend/components/WaypointCard.tsx
+++ b/src/frontend/components/WaypointCard.tsx
@@ -21,27 +21,13 @@ export const WaypointCard: FC<{
   readonly waypoint: Waypoint;
   readonly pathId: string;
   readonly refresh: () => void;
-}> = ({ waypoint, pathId, refresh }) => {
+  readonly owner: string;
+}> = ({ waypoint, pathId, refresh, owner }) => {
   const [isEditting, setIsEditting] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
-  const { user, setUser } = useContext(UserContext);
+  const { user} = useContext(UserContext);
   const [path, setPath] = useState<Path | undefined>(undefined);
   const [loading, setLoading] = useState(true);
-
-  const fetchPath = useCallback(() => {
-    api
-      .getPath(pathId)
-      .then((found) => {
-        setPath(found);
-        setLoading(false);
-      })
-      .catch(captureError);
-  }, [pathId]);
-
-  useEffect(() => {
-    fetchPath();
-  }, [fetchPath]);
-
 
   const submitEdit = useCallback(
     (payload: WaypointPayload) => {
@@ -79,7 +65,7 @@ export const WaypointCard: FC<{
             />
           )}
         </CardBody>
-        {!isEditting && path?.owner.username === user?.username && (
+        {!isEditting && owner === user?.username && (
           <CardFooter className="float-right">
             <Button
               onClick={() => {

--- a/src/frontend/components/WaypointCard.tsx
+++ b/src/frontend/components/WaypointCard.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useState } from 'react';
+import React, { FC, useCallback, useContext, useEffect, useState } from 'react';
 import {
   Button,
   Card,
@@ -14,6 +14,8 @@ import { captureError } from '../utils';
 import { Waypoint } from '../../shared/models/Waypoint';
 import { WaypointForm } from '../components/WaypointForm';
 import { WaypointPayload } from '../../shared/Payloads';
+import { UserContext } from '../services/providers';
+import { Path } from '../../shared/models/Path';
 
 export const WaypointCard: FC<{
   readonly waypoint: Waypoint;
@@ -22,6 +24,25 @@ export const WaypointCard: FC<{
 }> = ({ waypoint, pathId, refresh }) => {
   const [isEditting, setIsEditting] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+  const { user, setUser } = useContext(UserContext);
+  const [path, setPath] = useState<Path | undefined>(undefined);
+  const [loading, setLoading] = useState(true);
+
+  const fetchPath = useCallback(() => {
+    api
+      .getPath(pathId)
+      .then((found) => {
+        setPath(found);
+        setLoading(false);
+      })
+      .catch(captureError);
+  }, [pathId]);
+
+  useEffect(() => {
+    fetchPath();
+  }, [fetchPath]);
+
+
   const submitEdit = useCallback(
     (payload: WaypointPayload) => {
       api
@@ -58,7 +79,7 @@ export const WaypointCard: FC<{
             />
           )}
         </CardBody>
-        {!isEditting && (
+        {!isEditting && path?.owner.username === user?.username && (
           <CardFooter className="float-right">
             <Button
               onClick={() => {

--- a/src/frontend/components/WaypointCard.tsx
+++ b/src/frontend/components/WaypointCard.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useContext, useEffect, useState } from 'react';
+import React, { FC, useCallback, useContext, useState } from 'react';
 import {
   Button,
   Card,
@@ -15,7 +15,6 @@ import { Waypoint } from '../../shared/models/Waypoint';
 import { WaypointForm } from '../components/WaypointForm';
 import { WaypointPayload } from '../../shared/Payloads';
 import { UserContext } from '../services/providers';
-import { Path } from '../../shared/models/Path';
 
 export const WaypointCard: FC<{
   readonly waypoint: Waypoint;
@@ -25,9 +24,7 @@ export const WaypointCard: FC<{
 }> = ({ waypoint, pathId, refresh, owner }) => {
   const [isEditting, setIsEditting] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
-  const { user} = useContext(UserContext);
-  const [path, setPath] = useState<Path | undefined>(undefined);
-  const [loading, setLoading] = useState(true);
+  const { user } = useContext(UserContext);
 
   const submitEdit = useCallback(
     (payload: WaypointPayload) => {

--- a/src/frontend/containers/PathPage.tsx
+++ b/src/frontend/containers/PathPage.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useEffect, useState } from 'react';
+import React, { FC, useCallback, useContext, useEffect, useState } from 'react';
 import { Button, Modal, ModalBody, ModalHeader, Spinner } from 'reactstrap';
 import { Path } from '../../shared/models/Path';
 import { useParams } from 'react-router-dom';
@@ -7,6 +7,7 @@ import { WaypointForm } from '../components/WaypointForm';
 import { WaypointPayload } from '../../shared/Payloads';
 import { toast } from 'react-toastify';
 import { WaypointCard } from '../components/WaypointCard';
+import { UserContext } from '../services/providers';
 
 export const PathPage: FC = () => {
   const { pathId } = useParams();
@@ -14,6 +15,7 @@ export const PathPage: FC = () => {
   const [path, setPath] = useState<Path | undefined>(undefined);
   const [loading, setLoading] = useState(true);
   const [creating, setCreating] = useState(false);
+  const { user, setUser } = useContext(UserContext);
 
   const fetchPath = useCallback(() => {
     api
@@ -54,16 +56,18 @@ export const PathPage: FC = () => {
     <>
       <h1>Viewing: {path.name}</h1>
       <h2>Waypoints</h2>
-      <div className="float-right">
-        <Button
-          color="primary"
-          onClick={() => {
-            setCreating(true);
-          }}
-        >
-          New Waypoint
-        </Button>
-      </div>
+      {path.owner.username === user?.username ? (
+        <div className="float-right">
+          <Button
+            color="primary"
+            onClick={() => {
+              setCreating(true);
+            }}
+          >
+            New Waypoint
+          </Button>
+        </div>
+      ) : (<></>)}
       {path.waypoints.map((wp) => (
         <WaypointCard refresh={fetchPath} pathId={path.id} waypoint={wp} key={wp.id} />
       ))}

--- a/src/frontend/containers/PathPage.tsx
+++ b/src/frontend/containers/PathPage.tsx
@@ -56,7 +56,7 @@ export const PathPage: FC = () => {
     <>
       <h1>Viewing: {path.name}</h1>
       <h2>Waypoints</h2>
-      {path.owner.username === user?.username ? (
+      {path.owner.username === user?.username && (
         <div className="float-right">
           <Button
             color="primary"
@@ -67,9 +67,9 @@ export const PathPage: FC = () => {
             New Waypoint
           </Button>
         </div>
-      ) : (<></>)}
+      )}
       {path.waypoints.map((wp) => (
-        <WaypointCard refresh={fetchPath} pathId={path.id} waypoint={wp} key={wp.id} />
+        <WaypointCard refresh={fetchPath} pathId={path.id} waypoint={wp} owner={path.owner.username} key={wp.id} />
       ))}
       <Modal
         isOpen={creating}

--- a/src/frontend/containers/PathPage.tsx
+++ b/src/frontend/containers/PathPage.tsx
@@ -15,7 +15,7 @@ export const PathPage: FC = () => {
   const [path, setPath] = useState<Path | undefined>(undefined);
   const [loading, setLoading] = useState(true);
   const [creating, setCreating] = useState(false);
-  const { user, setUser } = useContext(UserContext);
+  const { user } = useContext(UserContext);
 
   const fetchPath = useCallback(() => {
     api
@@ -69,7 +69,13 @@ export const PathPage: FC = () => {
         </div>
       )}
       {path.waypoints.map((wp) => (
-        <WaypointCard refresh={fetchPath} pathId={path.id} waypoint={wp} owner={path.owner.username} key={wp.id} />
+        <WaypointCard
+          refresh={fetchPath}
+          pathId={path.id}
+          waypoint={wp}
+          owner={path.owner.username}
+          key={wp.id}
+        />
       ))}
       <Modal
         isOpen={creating}


### PR DESCRIPTION
#### PR Checklist

- [ ] Tested the result locally.
- [ ] Attached screenshots of major UI changes.

#### User Story or Issue Addressed

A user must be unable to see edit and delete options for paths they dont own

#### What changes did you make?

User can only see the add waypoint button and edit and delete buttons for each path if it belongs to them

#### Why did you make these changes?

Users shouldn't be able to see the options to change paths they don't own to avoid confusion
